### PR TITLE
HRCPP-254 StringSerializerHotRodTest.testDotNetGet fails

### DIFF
--- a/java_tests/src/test/java/org/infinispan/client/hotrod/StringSerializerHotRodTest.java
+++ b/java_tests/src/test/java/org/infinispan/client/hotrod/StringSerializerHotRodTest.java
@@ -66,15 +66,12 @@ public class StringSerializerHotRodTest extends SingleCacheManagerTest implement
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       // Enable statistics in the global configuration
       Object config = hotRodCacheConfiguration();
-      ((ConfigurationBuilder) config).jmxStatistics().enable()
-        .compatibility().enable()
-        .dataContainer().keyEquivalence(EQUIVALENCE).valueEquivalence(EQUIVALENCE);
+      ((ConfigurationBuilder) config).jmxStatistics().enable();
 
       cacheManager = TestCacheManagerFactory.createCacheManager((ConfigurationBuilder) config);
       cacheManager.defineConfiguration(DEFAULT_CACHE, ((ConfigurationBuilder) config).build());
 
       hotrodServer = startHotRodServer(cacheManager);
-
       // this is a safer way to load the java hotrod client, without relying on the classpath
       dotnetClassLoader = new InvertedURLClassLoader(getClientURL("infinispan.client.hotrod.dotnet"));
       boolean useCompatibilityStringSerializer = true;
@@ -191,13 +188,13 @@ public class StringSerializerHotRodTest extends SingleCacheManagerTest implement
    public void testDotNetGet() throws Exception {
       log.info("doDotNetGet()");
       initEmptyCaches();
-
+     
       for (int i = 0; i < valueArray.length; i++) {
          javaCache.put("k" + i, valueArray[i]);
       }
       
       assertEquals(dotnetCache.size(), valueArray.length);
-      
+
       for (int i = 0; i < valueArray.length; i++) {
          assertEquals(dotnetCache.get("k" + i), valueArray[i]);
       }
@@ -210,7 +207,7 @@ public class StringSerializerHotRodTest extends SingleCacheManagerTest implement
 
    public static void main(String[] args) {
       TestNG testng = new TestNG();
-     testng.addMethodSelector("org.infinispan.client.hotrod.StringSerializerHotRodTest", 1);
+      testng.addMethodSelector("org.infinispan.client.hotrod.StringSerializerHotRodTest", 1);
       TextReporter tr = new TextReporter("StringSerializer Test", 2);
       testng.setTestClasses(new Class[] {
          StringSerializerHotRodTest.class
@@ -218,9 +215,7 @@ public class StringSerializerHotRodTest extends SingleCacheManagerTest implement
 
       testng.addListener(tr);
       testng.run();
-      Set<String> expectedTestFailures = new TreeSet<String>(Arrays.asList( 
-			      "StringSerializerHotRodTest.testDotNetGet"
-      ));
+      Set<String> expectedTestFailures = new TreeSet<String>();
       Set<String> expectedSkips = Collections.emptySet();
 
       Set<String> failures = new TreeSet<String>();


### PR DESCRIPTION
https://issues.jboss.org/browse/HRCPP-254

It appears this test no longer requires compatibility mode enabled. I was trying to find the cause but didn't find it in the C# client itself. Maybe there were some changes in the C++ client which cause this. Anyway, the fact that the compatibility mode is not required seems correct to me. In our documentation, we don't mention compatibility mode for interoperability between Java, Cpp and C# clients, except this specific usecase with StringSerializer. I think it is correct that compat mode is not required for this use case either now.