### PR TITLE
HRCPP-281 Removed Builder<T> reference in swig

### DIFF
--- a/src/main/cs/Infinispan/HotRod/Impl/RemoteCacheSWIGImpl.cs
+++ b/src/main/cs/Infinispan/HotRod/Impl/RemoteCacheSWIGImpl.cs
@@ -209,7 +209,7 @@ namespace Infinispan.HotRod.Impl
                 }
             }
             
-            return result;
+            return (ISet<K>)result;
         }
 
         public IList<V> Values()

--- a/swig/hotrod_arch.i
+++ b/swig/hotrod_arch.i
@@ -1,4 +1,4 @@
-%typemap(csinterfaces_derived) infinispan::hotrod::ConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.ConfigurationBuilder"
+%typemap(csinterfaces) infinispan::hotrod::ConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.ConfigurationBuilder"
 %typemap(cscode) infinispan::hotrod::ConfigurationBuilder %{
     public void Read(Infinispan.HotRod.SWIG.Configuration bean) {
         read((Configuration) bean);

--- a/swig/hotrodcs.i
+++ b/swig/hotrodcs.i
@@ -2,7 +2,6 @@
 
 %{
 #include <infinispan/hotrod/BasicMarshaller.h>
-#include <infinispan/hotrod/Builder.h>
 #include <infinispan/hotrod/FailOverRequestBalancingStrategy.h>
 #include <infinispan/hotrod/Configuration.h>
 #include <infinispan/hotrod/ConfigurationBuilder.h>
@@ -76,7 +75,6 @@
 %include "infinispan/hotrod/InetSocketAddress.h"
 %include "infinispan/hotrod/CacheTopologyInfo.h"
 
-%include "infinispan/hotrod/Builder.h"
 
 
 %include "infinispan/hotrod/ConnectionPoolConfiguration.h"
@@ -85,10 +83,6 @@
 %include "infinispan/hotrod/FailOverRequestBalancingStrategy.h"
 %include "infinispan/hotrod/Configuration.h"
 
-%template(BuilderConf) infinispan::hotrod::Builder<infinispan::hotrod::Configuration>;
-%template(BuilderServerConf) infinispan::hotrod::Builder<infinispan::hotrod::ServerConfiguration>;
-%template(BuilderPoolConf) infinispan::hotrod::Builder<infinispan::hotrod::ConnectionPoolConfiguration>;
-%template(BuilderSSLConf) infinispan::hotrod::Builder<infinispan::hotrod::SslConfiguration>;
 
 %include "infinispan/hotrod/ConfigurationChildBuilder.h"
 %include "infinispan/hotrod/ConnectionPoolConfigurationBuilder.h"


### PR DESCRIPTION
Removed Builder<T> references in swig .i files.
Changed the typemap attribute to generate the correct inheritance for ConfigurationBuilder