### PR TITLE
HRCPP-326 # added AddCluster to the C# API

### DIFF
--- a/src/main/cs/Infinispan/HotRod/Config/ClusterConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/ClusterConfigurationBuilder.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Infinispan.HotRod.SWIG;
+#pragma warning disable 1591
+namespace Infinispan.HotRod.Config
+{
+    public class ClusterConfigurationBuilder
+    {
+        private Infinispan.HotRod.SWIG.ClusterConfigurationBuilder jniBuilder;
+        internal ClusterConfigurationBuilder(Infinispan.HotRod.SWIG.ClusterConfigurationBuilder jniBuilder)
+        {
+            this.jniBuilder = jniBuilder;
+        }
+
+        public ClusterConfigurationBuilder AddClusterNode(string host, int port)
+        {
+            jniBuilder.AddClusterNode(host, port);
+            return this;
+        }
+
+    }
+}
+#pragma warning restore 1591

--- a/src/main/cs/Infinispan/HotRod/Config/ConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/ConfigurationBuilder.cs
@@ -103,6 +103,11 @@ namespace Infinispan.HotRod.Config
             return this;
         }
 
+        public ClusterConfigurationBuilder AddCluster(string clusterName)
+        {
+            return new ClusterConfigurationBuilder(builder.AddCluster(clusterName));
+        }
+
         public ConfigurationBuilder Marshaller(IMarshaller marshaller)
         {
             this.marshaller = marshaller;

--- a/src/main/cs/Infinispan/HotRod/SWIG/ClusterConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/SWIG/ClusterConfigurationBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace Infinispan.HotRod.SWIG
+{
+    internal interface ClusterConfigurationBuilder
+    {
+        ClusterConfigurationBuilder AddClusterNode(string host, int port);
+    }
+}

--- a/src/main/cs/Infinispan/HotRod/SWIG/ConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/SWIG/ConfigurationBuilder.cs
@@ -6,6 +6,7 @@ namespace Infinispan.HotRod.SWIG
     {
         Configuration Create();
         ServerConfigurationBuilder AddServer();
+        ClusterConfigurationBuilder AddCluster(string clusterName);
         ConnectionPoolConfigurationBuilder ConnectionPool();
         SslConfigurationBuilder Ssl();
 

--- a/swig/hotrod_arch.i
+++ b/swig/hotrod_arch.i
@@ -53,6 +53,10 @@
         return maxRetries(_maxRetries);
     }
     
+    public Infinispan.HotRod.SWIG.ClusterConfigurationBuilder AddCluster(string _clusterName) {
+        return addCluster(_clusterName);
+    }
+    
     %}
 
 %typemap(csinterfaces_derived) infinispan::hotrod::ServerConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.ServerConfigurationBuilder"
@@ -184,6 +188,12 @@
     }
     %}
 
+%typemap(csinterfaces) infinispan::hotrod::ClusterConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.ClusterConfigurationBuilder"
+%typemap(cscode) infinispan::hotrod::ClusterConfigurationBuilder %{
+public Infinispan.HotRod.SWIG.ClusterConfigurationBuilder AddClusterNode(string host, int port) {
+       return addClusterNode(host, port);
+    }
+%}
 %typemap(csinterfaces) infinispan::hotrod::Configuration "IDisposable, Infinispan.HotRod.SWIG.Configuration"
 %typemap(cscode) infinispan::hotrod::Configuration %{
 public System.Collections.Generic.IList<Infinispan.HotRod.SWIG.ServerConfiguration> Servers() {


### PR DESCRIPTION
Added ConfigurationBuilder::AddCluster and ClusterConfigurationBuilder class. 
User can now configure different clusters.

This fixes https://issues.jboss.org/browse/HRCPP-326