### PR TITLE
Hrcpp 298/cs near cache

### DIFF
--- a/src/main/cs/Infinispan/HotRod/Config/ConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/ConfigurationBuilder.cs
@@ -84,6 +84,11 @@ namespace Infinispan.HotRod.Config
         {
             return new SslConfigurationBuilder(this, builder.Ssl());
         }
+
+        public NearCacheConfigurationBuilder NearCache()
+        {
+            return new NearCacheConfigurationBuilder(this, builder.NearCache());
+        }
     
         public ConfigurationBuilder TcpNoDelay(bool tcpNoDelay)
         {

--- a/src/main/cs/Infinispan/HotRod/Config/NearCacheConfiguration.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/NearCacheConfiguration.cs
@@ -1,0 +1,22 @@
+using Infinispan.HotRod.SWIG;
+
+namespace Infinispan.HotRod.Config
+{
+    /// <summary>
+    ///   Used to hold the SSL specific configurations.
+    /// </summary>
+    public class NearCacheConfiguration
+    {
+        private Infinispan.HotRod.SWIG.NearCacheConfiguration config;
+
+        internal NearCacheConfiguration(Infinispan.HotRod.SWIG.NearCacheConfiguration config)
+        {
+            this.config = config;
+        }
+
+        internal Infinispan.HotRod.SWIG.NearCacheConfiguration Config()
+        {
+            return config;
+        }
+    }
+}

--- a/src/main/cs/Infinispan/HotRod/Config/NearCacheConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/NearCacheConfigurationBuilder.cs
@@ -1,0 +1,35 @@
+namespace Infinispan.HotRod.Config
+{
+#pragma warning disable 1591
+    public class NearCacheConfigurationBuilder: AbstractConfigurationChildBuilder
+    {
+        private Infinispan.HotRod.SWIG.NearCacheConfigurationBuilder jniBuilder;
+
+        internal NearCacheConfigurationBuilder(ConfigurationBuilder parentBuilder, Infinispan.HotRod.SWIG.NearCacheConfigurationBuilder jniBuilder) : base(parentBuilder)
+        { 
+            this.jniBuilder = jniBuilder;
+        }
+
+        public void Validate()
+        {
+        }
+
+        public NearCacheConfiguration Create()
+        {
+            return new NearCacheConfiguration(jniBuilder.Create());
+        }
+
+        public NearCacheConfigurationBuilder Mode(NearCacheMode _mode)
+        {
+            jniBuilder.Mode(_mode);
+            return this;
+        }
+
+        public NearCacheConfigurationBuilder MaxEntries(int _maxEntries)
+        {
+            jniBuilder.MaxEntries(_maxEntries);
+            return this;
+        }
+    }
+#pragma warning restore 1591
+}

--- a/src/main/cs/Infinispan/HotRod/NearCacheMode.cs
+++ b/src/main/cs/Infinispan/HotRod/NearCacheMode.cs
@@ -1,0 +1,13 @@
+namespace Infinispan.HotRod
+{
+    /// <summary>
+    ///   Near cache mode
+    /// </summary>
+    public enum NearCacheMode
+    {
+#pragma warning disable 1591
+	    DISABLED = 0,
+	    INVALIDATED = 1
+#pragma warning restore 1591
+    }
+}

--- a/src/main/cs/Infinispan/HotRod/SWIG/ConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/SWIG/ConfigurationBuilder.cs
@@ -9,6 +9,7 @@ namespace Infinispan.HotRod.SWIG
         ClusterConfigurationBuilder AddCluster(string clusterName);
         ConnectionPoolConfigurationBuilder ConnectionPool();
         SslConfigurationBuilder Ssl();
+        NearCacheConfigurationBuilder NearCache();
 
         void validate();
         ConfigurationBuilder AddServers(string serverList);

--- a/src/main/cs/Infinispan/HotRod/SWIG/NearCacheConfiguration.cs
+++ b/src/main/cs/Infinispan/HotRod/SWIG/NearCacheConfiguration.cs
@@ -1,0 +1,6 @@
+namespace Infinispan.HotRod.SWIG
+{
+    internal interface NearCacheConfiguration
+    {
+    }
+}

--- a/src/main/cs/Infinispan/HotRod/SWIG/NearCacheConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/SWIG/NearCacheConfigurationBuilder.cs
@@ -1,0 +1,11 @@
+namespace Infinispan.HotRod.SWIG {
+using Infinispan.HotRod;
+    internal interface NearCacheConfigurationBuilder
+    {
+          NearCacheConfiguration Create();
+          NearCacheConfigurationBuilder Mode(NearCacheMode mode);
+          NearCacheMode GetMode();
+          NearCacheConfigurationBuilder MaxEntries(int maxEntries);
+          int GetMaxEntries();
+    }
+}

--- a/src/test/cs/Infinispan/HotRod/NearCacheTest.cs
+++ b/src/test/cs/Infinispan/HotRod/NearCacheTest.cs
@@ -1,0 +1,60 @@
+﻿using Infinispan.HotRod.Config;
+using System.Collections.Generic;
+using Infinispan.HotRod.Tests.Util;
+using NUnit.Framework;
+
+namespace Infinispan.HotRod.Tests
+{
+    class NearCacheTest
+    {
+        RemoteCacheManager remoteManager;
+        const string ERRORS_KEY_SUFFIX = ".errors";
+        const string PROTOBUF_SCRIPT_CACHE_NAME = "___script_cache";
+        IMarshaller marshaller;
+
+        [TestFixtureSetUp]
+        public void BeforeClass()
+        {
+            ConfigurationBuilder conf = new ConfigurationBuilder();
+            conf.AddServer().Host("127.0.0.1").Port(11222);
+            conf.ConnectionTimeout(90000).SocketTimeout(6000);
+            conf.NearCache().Mode(NearCacheMode.INVALIDATED).MaxEntries(10);
+            marshaller = new JBasicMarshaller();
+            conf.Marshaller(marshaller);
+            remoteManager = new RemoteCacheManager(conf.Build(), true);
+        }
+
+
+        [Test]
+        public void PopulateNearCacheTest()
+        {
+            var cache = remoteManager.GetCache<string, string>();
+            cache.Clear();
+            var stats0 = cache.Stats();
+            cache.Get("key1");
+            cache.Put("key1", "value1");
+            // key1 is near now
+            cache.Get("key1");
+            var stats1 = cache.Stats();
+            // Retrieve stats form the server and do some checks
+            // counters don't consider hit and miss on the near cache
+            Assert.AreEqual(stats0.GetStatistic("hits"), stats1.GetStatistic("hits"));
+            Assert.AreEqual(int.Parse(stats0.GetStatistic("misses"))+1, int.Parse(stats1.GetStatistic("misses")));
+            // now fill the near cache
+            for (int i=0; i<=10; i++)
+            {
+                cache.Put("key" + (i+2), "value" + (i+2));
+            }
+            // key1 is now far
+            cache.Get("key1");
+            // key1 push key2 out from near cache
+            // key2 is now far
+            cache.Get("key2");
+            // key4 is near
+            cache.Get("key4");
+            var stats2 = cache.Stats();
+            Assert.AreEqual(stats1.GetStatistic("misses"), stats2.GetStatistic("misses"));
+            Assert.AreEqual(int.Parse(stats1.GetStatistic("hits")) + 3, int.Parse(stats2.GetStatistic("hits")));
+        }
+    }
+}

--- a/swig/hotrod_arch.i
+++ b/swig/hotrod_arch.i
@@ -17,6 +17,10 @@
         return ssl();
     }
 
+    public Infinispan.HotRod.SWIG.NearCacheConfigurationBuilder NearCache() {
+        return nearCache();
+    }
+
     public Infinispan.HotRod.SWIG.ConfigurationBuilder AddServers(string _serverList) {
         return addServers(_serverList);
     }
@@ -188,6 +192,38 @@
     }
     %}
 
+%typemap(csinterfaces_derived) infinispan::hotrod::NearCacheConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.NearCacheConfigurationBuilder"
+%typemap(cscode) infinispan::hotrod::NearCacheConfigurationBuilder %{
+
+    public Infinispan.HotRod.SWIG.NearCacheConfiguration Create() {
+        return create();
+    }
+
+    public Infinispan.HotRod.SWIG.NearCacheConfigurationBuilder Mode(Infinispan.HotRod.NearCacheMode _mode) {
+        switch(_mode) {
+              case Infinispan.HotRod.NearCacheMode.INVALIDATED: return mode(NearCacheMode.INVALIDATED);
+              case Infinispan.HotRod.NearCacheMode.DISABLED:
+              default: return mode(NearCacheMode.DISABLED);
+        }
+    }
+
+    public Infinispan.HotRod.NearCacheMode GetMode() {
+        switch(getMode()) {
+              case NearCacheMode.INVALIDATED: return Infinispan.HotRod.NearCacheMode.INVALIDATED;
+              case NearCacheMode.DISABLED:
+              default: return Infinispan.HotRod.NearCacheMode.DISABLED;
+        }
+    }
+
+    public Infinispan.HotRod.SWIG.NearCacheConfigurationBuilder MaxEntries(int maxEntries) {
+        return this.maxEntries(maxEntries);
+    }
+
+    public int GetMaxEntries() {
+        return getMaxEntries();
+    }
+    %}
+
 %typemap(csinterfaces) infinispan::hotrod::ClusterConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.ClusterConfigurationBuilder"
 %typemap(cscode) infinispan::hotrod::ClusterConfigurationBuilder %{
 public Infinispan.HotRod.SWIG.ClusterConfigurationBuilder AddClusterNode(string host, int port) {
@@ -226,10 +262,15 @@ public System.Collections.Generic.Dictionary<string, System.Collections.Generic.
     public Infinispan.HotRod.SWIG.SslConfiguration Ssl() {
         return getSslConfiguration();
     }
+
+    public Infinispan.HotRod.SWIG.NearCacheConfiguration NearCache() {
+        return getNearCacheConfiguration();
+    }
     %}
 
 %typemap(csinterfaces) infinispan::hotrod::ServerConfiguration "IDisposable, Infinispan.HotRod.SWIG.ServerConfiguration"
 %typemap(csinterfaces) infinispan::hotrod::SslConfiguration "IDisposable, Infinispan.HotRod.SWIG.SslConfiguration"
+%typemap(csinterfaces) infinispan::hotrod::NearCacheConfiguration "IDisposable, Infinispan.HotRod.SWIG.NearCacheConfiguration"
 
 %typemap(csinterfaces) infinispan::hotrod::ConnectionPoolConfiguration "IDisposable, Infinispan.HotRod.SWIG.ConnectionPoolConfiguration"
 %typemap(cscode) infinispan::hotrod::ConnectionPoolConfiguration %{

--- a/swig/hotrodcs.i
+++ b/swig/hotrodcs.i
@@ -24,6 +24,7 @@ namespace org { namespace infinispan { namespace query { namespace remote { name
 #include <infinispan/hotrod/ServerConfiguration.h>
 #include <infinispan/hotrod/ServerConfigurationBuilder.h>
 #include <infinispan/hotrod/SslConfiguration.h>
+#include <infinispan/hotrod/NearCacheConfiguration.h>
 #include <infinispan/hotrod/SslConfigurationBuilder.h>
 #include <infinispan/hotrod/TimeUnit.h>
 #include <infinispan/hotrod/Version.h>
@@ -90,6 +91,7 @@ namespace org { namespace infinispan { namespace query { namespace remote { name
 %include "infinispan/hotrod/ConnectionPoolConfiguration.h"
 %include "infinispan/hotrod/ServerConfiguration.h"
 %include "infinispan/hotrod/SslConfiguration.h"
+%include "infinispan/hotrod/NearCacheConfiguration.h"
 %include "infinispan/hotrod/FailOverRequestBalancingStrategy.h"
 %include "infinispan/hotrod/Configuration.h"
 


### PR DESCRIPTION
Glue code that exposes near cache configuration stuff to the C# client.

Fixes the C# side of this issue: https://issues.jboss.org/browse/HRCPP-298