### PR TITLE
HRCPP-303 # fix

### DIFF
--- a/src/main/resources/proto/org/infinispan/protostream/message-wrapping.proto
+++ b/src/main/resources/proto/org/infinispan/protostream/message-wrapping.proto
@@ -14,6 +14,7 @@ message WrappedMessage {
    //TODO [anistor] use 'oneof' introduced in protobuf 2.6.0
 
    // only one of these fields is used if the wrapped value is a scalar type
+oneof ScalarOrMessage {
     double wrappedDouble = 1;
     float wrappedFloat = 2;
     int64 wrappedInt64 = 3;
@@ -35,12 +36,14 @@ message WrappedMessage {
 
    // this is used if the wrapped value is a message
     bytes wrappedMessageBytes = 17;
-
+}
+   oneof TypeNameOrId {
    // this is used if the wrapped value is an enum
     int32 wrappedEnum = 18;
 
    // this is used as an alternative to wrappedDescriptorFullName if a unique id was assigned to the type
     int32 wrappedDescriptorId = 19;
+}
 }
 
 

--- a/src/test/cs/Infinispan/HotRod/RemoteQueryTest.cs
+++ b/src/test/cs/Infinispan/HotRod/RemoteQueryTest.cs
@@ -557,7 +557,6 @@ namespace Infinispan.HotRod.Tests
         }
 
         [Test]
-        [Ignore("https://issues.jboss.org/browse/HRCPP-303")]
         public void CountTest()
         {
             IRemoteCache<int, User> userCache = remoteManager.GetCache<int, User>(NAMED_CACHE);
@@ -618,14 +617,60 @@ namespace Infinispan.HotRod.Tests
                 for (int j = 0; j < resp.ProjectionSize; j++)
                 {
                     WrappedMessage wm = resp.Results.ElementAt(i * resp.ProjectionSize + j);
-                    if (wm.WrappedString != null)
-                        projection[j] = wm.WrappedString;
-                    if (wm.WrappedInt32 != 0)
-                        projection[j] = wm.WrappedInt32;
-                    if (wm.WrappedDouble != 0.0)
-                        projection[j] = wm.WrappedDouble;
-                    if (wm.WrappedInt64 != 0)
-                        projection[j] = wm.WrappedInt64;
+                    switch (wm.ScalarOrMessageCase)
+                    {
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedDouble:
+                            projection[j] = wm.WrappedDouble;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedFloat:
+                            projection[j] = wm.WrappedFloat;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedInt64:
+                            projection[j] = wm.WrappedInt64;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedUInt64:
+                            projection[j] = wm.WrappedUInt64;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedInt32:
+                            projection[j] = wm.WrappedInt32;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedFixed64:
+                            projection[j] = wm.WrappedFixed64;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedFixed32:
+                            projection[j] = wm.WrappedFixed32;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedBool:
+                            projection[j] = wm.WrappedBool;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedString:
+                            projection[j] = wm.WrappedString;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedBytes:
+                            projection[j] = wm.WrappedBytes;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedUInt32:
+                            projection[j] = wm.WrappedUInt32;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedSFixed32:
+                            projection[j] = wm.WrappedSFixed32;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedSFixed64:
+                            projection[j] = wm.WrappedSFixed64;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedSInt32:
+                            projection[j] = wm.WrappedSInt32;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedSInt64:
+                            projection[j] = wm.WrappedSInt64;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedDescriptorFullName:
+                            projection[j] = wm.WrappedDescriptorFullName;
+                            break;
+                        case WrappedMessage.ScalarOrMessageOneofCase.WrappedMessageBytes:
+                            projection[j] = wm.WrappedMessageBytes;
+                            break;
+                    }
                 }
                 result.Add(projection);
             }


### PR DESCRIPTION
Added oneof to the message-wrapped.proto spec. Optional fields can now be better discriminated.

Fixes https://issues.jboss.org/browse/HRCPP-303
