### PR TITLE
HRCPP-302 # C# fix for repeated int32 field

### DIFF
--- a/src/test/cs/Infinispan/HotRod/RemoteQueryTest.cs
+++ b/src/test/cs/Infinispan/HotRod/RemoteQueryTest.cs
@@ -45,6 +45,7 @@ namespace Infinispan.HotRod.Tests
             }
 
             IRemoteCache<int, User> userCache = remoteManager.GetCache<int, User>(NAMED_CACHE);
+            userCache.Clear();
             PutUsers(userCache);
             IRemoteCache<int, Account> accountCache = remoteManager.GetCache<int, Account>(NAMED_CACHE);
             PutAccounts(accountCache);
@@ -686,9 +687,9 @@ namespace Infinispan.HotRod.Tests
             user1.Gender = User.Types.Gender.MALE;
             user1.Age = 22;
             user1.Notes = "Lorem ipsum dolor sit amet";
-            List<String> accountIds = new List<String>();
-            accountIds.Add("1");
-            accountIds.Add("2");
+            List<Int32> accountIds = new List<Int32>();
+            accountIds.Add(1);
+            accountIds.Add(2);
             user1.AccountIds.Add(accountIds);
             User.Types.Address address1 = new User.Types.Address();
             address1.Street = "Main Street";
@@ -705,8 +706,8 @@ namespace Infinispan.HotRod.Tests
             user2.Name = "Spider";
             user2.Surname = "Man";
             user2.Gender = User.Types.Gender.MALE;
-            accountIds = new List<String>();
-            accountIds.Add("3");
+            accountIds = new List<Int32>();
+            accountIds.Add(3);
             user2.AccountIds.Add(accountIds);
             User.Types.Address address2 = new User.Types.Address();
             address2.Street = "Old Street";
@@ -730,7 +731,7 @@ namespace Infinispan.HotRod.Tests
             user3.Gender = User.Types.Gender.FEMALE;
 
             remoteCache.Put(3, user3);
-            accountIds = new List<String>();
+            accountIds = new List<Int32>();
             user3.AccountIds.Add(accountIds);
         }
 

--- a/src/test/resources/proto2/bank.proto
+++ b/src/test/resources/proto2/bank.proto
@@ -18,7 +18,7 @@ message User {
     * @IndexedField()
     * Unable to use int32 type. See HRCPP-302.    
     */
-   repeated string accountIds = 2;
+   repeated int32 accountIds = 2;
 
    /**
     * @IndexedField

--- a/src/test/resources/proto3/bank.proto
+++ b/src/test/resources/proto3/bank.proto
@@ -17,9 +17,9 @@ message User {
 
    /**
     * @IndexedField()
-    * Unable to use int32 type. See HRCPP-302.    
+    * Protobuf 3 by default packs repeated fields. Packing needs to be explicitly disabled
     */
-   repeated string accountIds = 2;
+   repeated int32 accountIds = 2 [packed=false];
 
    /**
     * @IndexedField
@@ -141,7 +141,8 @@ message Transaction {
  *
  */
 message int_array {
-   repeated int32 theArray = 1;
+    /* Protobuf 3 by default packs repeated fields. Packing needs to be explicitly disabled */
+   repeated int32 theArray = 1 [packed=false];
 }
 
 /**


### PR DESCRIPTION
This is a fix for https://issues.jboss.org/browse/HRCPP-302.
Client uses protobuf  3 that by default packs repeated fields of fixed length. This feature must be explicitly disabled in the proto file [packed=false] to communicate correctly with the Infinispan server (protobuf 2).

