### PR TITLE
HRCPP-353 .NET test suite hides exceptions thrown during ISPN server …

### DIFF
--- a/src/test/cs/Infinispan/HotRod/Util/HotRodServer.cs
+++ b/src/test/cs/Infinispan/HotRod/Util/HotRodServer.cs
@@ -36,8 +36,9 @@ namespace Infinispan.HotRod.Tests.Util
             }
             catch (Exception ex)
             {
-                ShutDownHotrodServer();
+                Console.WriteLine(ex.Message);
                 Console.WriteLine(ex.StackTrace);
+                ShutDownHotrodServer();
                 throw ex;
             }
         }


### PR DESCRIPTION
…startup

https://issues.jboss.org/browse/HRCPP-353