### PR TITLE
Extend Remote Events tests

### DIFF
--- a/src/test/cs/Infinispan/HotRod/EventListener.cs
+++ b/src/test/cs/Infinispan/HotRod/EventListener.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using Infinispan.HotRod.Event;
+
+namespace Infinispan.HotRod.Tests
+{
+    class LoggingEventListener<E>
+    {
+        public BlockingCollection<Event.ClientCacheEntryCreatedEvent<E>> createdEvents = new BlockingCollection<Event.ClientCacheEntryCreatedEvent<E>>();
+        public BlockingCollection<Event.ClientCacheEntryRemovedEvent<E>> removedEvents = new BlockingCollection<Event.ClientCacheEntryRemovedEvent<E>>();
+        public BlockingCollection<Event.ClientCacheEntryModifiedEvent<E>> modifiedEvents = new BlockingCollection<Event.ClientCacheEntryModifiedEvent<E>>();
+        public BlockingCollection<Event.ClientCacheEntryExpiredEvent<E>> expiredEvents = new BlockingCollection<Event.ClientCacheEntryExpiredEvent<E>>();
+
+        public void CreatedEventAction(Event.ClientCacheEntryCreatedEvent<E> e)
+        {
+            createdEvents.Add(e);
+        }
+
+        public void RemovedEventAction(Event.ClientCacheEntryRemovedEvent<E> e)
+        {
+            removedEvents.Add(e);
+        }
+
+        public void ModifiedEventAction(Event.ClientCacheEntryModifiedEvent<E> e)
+        {
+            modifiedEvents.Add(e);
+        }
+
+        public void ExpiredEventAction(Event.ClientCacheEntryExpiredEvent<E> e)
+        {
+            expiredEvents.Add(e);
+        }
+
+        public Event.ClientCacheEntryCreatedEvent<E> PollCreatedEvent()
+        {
+            return PollEvent<Event.ClientCacheEntryCreatedEvent<E>>(typeof(Event.ClientCacheEntryCreatedEvent<E>));
+        }
+
+        public Event.ClientCacheEntryRemovedEvent<E> PollRemovedEvent()
+        {
+            return PollEvent<Event.ClientCacheEntryRemovedEvent<E>>(typeof(Event.ClientCacheEntryRemovedEvent<E>));
+        }
+
+        public Event.ClientCacheEntryModifiedEvent<E> PollModifiedEvent()
+        {
+            return PollEvent<Event.ClientCacheEntryModifiedEvent<E>>(typeof(Event.ClientCacheEntryModifiedEvent<E>));
+        }
+
+        public Event.ClientCacheEntryExpiredEvent<E> PollExpiredEvent()
+        {
+            return PollEvent<Event.ClientCacheEntryExpiredEvent<E>>(typeof(Event.ClientCacheEntryExpiredEvent<E>));
+        }
+
+        private T PollEvent<T>(Type eventType) where T : ClientEvent
+        {
+            var tokenSource = new CancellationTokenSource();
+            var token = tokenSource.Token;
+            tokenSource.CancelAfter(10000);
+            try
+            {
+                if (eventType == typeof(Event.ClientCacheEntryCreatedEvent<E>))
+                {
+                    return createdEvents.Take(token) as T;
+                }
+                else if (eventType == typeof(Event.ClientCacheEntryRemovedEvent<E>))
+                {
+                    return removedEvents.Take(token) as T;
+                }
+                else if (eventType == typeof(Event.ClientCacheEntryModifiedEvent<E>))
+                {
+                    return modifiedEvents.Take(token) as T;
+                }
+                else if (eventType == typeof(Event.ClientCacheEntryExpiredEvent<E>))
+                {
+                    return expiredEvents.Take(token) as T;
+                }
+                else
+                {
+                    throw new ArgumentException("Uknown event type");
+                }
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new TimeoutException("The event of type " + eventType.ToString() + " was not received within timeout!", ex);
+            }
+        }
+    }
+}

--- a/src/test/cs/Infinispan/HotRod/Util/TimeUtils.cs
+++ b/src/test/cs/Infinispan/HotRod/Util/TimeUtils.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace Infinispan.HotRod.Tests.Util
+{
+    class TimeUtils
+    {
+        /*
+         * Waits for a condition to be satisfied.
+         * Accepts a function without parameters, returning bool value.
+         */
+        public static void WaitFor(Func<bool> condition, long waitTime = 1000, int pollInterval = 100)
+        {
+            var stopWatch = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                while (stopWatch.ElapsedMilliseconds <= waitTime)
+                {
+                    if (condition()) return;
+                    System.Threading.Thread.Sleep(pollInterval);
+                }
+            }
+            finally
+            {
+                stopWatch.Stop();
+                Assert.IsTrue(condition());
+            }
+        }
+    }
+}


### PR DESCRIPTION
* cover expiration events
* cover conditional operations

Also remove the tests for individual operations and cover them all in a single test method.