### PR TITLE
HRCPP-360 # fixed types mismatch

### DIFF
--- a/java_tests/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/java_tests/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -584,7 +584,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheUnsupported<K, V> {
             if (vv == null) {
                 return null;
             }
-            return new VersionedValueImpl<V>(vv.GetVersion(),
+            return new VersionedValueImpl<V>(cli.System.Convert.ToInt64(vv.GetVersion()),
                                              (V) unmarshal(vv.GetValue()));
         } catch (cli.Infinispan.HotRod.Exceptions.RemoteCacheManagerNotStartedException ex) {
             throw new RemoteCacheManagerNotStartedException(ex.get_Message());
@@ -605,7 +605,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheUnsupported<K, V> {
                                             mv.GetLifespan(),
                                             mv.GetLastUsed(),
                                             mv.GetMaxIdle(),
-                                            mv.GetVersion(),
+                                            cli.System.Convert.ToInt64(mv.GetVersion()),
                                             (V) unmarshal(mv.GetValue()));
         } catch (cli.Infinispan.HotRod.Exceptions.RemoteCacheManagerNotStartedException ex) {
             throw new RemoteCacheManagerNotStartedException(ex.get_Message());

--- a/src/main/cs/Infinispan/HotRod/IVersionedValue.cs
+++ b/src/main/cs/Infinispan/HotRod/IVersionedValue.cs
@@ -24,6 +24,6 @@ namespace Infinispan.HotRod
            Returns the versioned associated with the value.
            </summary>
         */
-        long GetVersion();
+        ulong GetVersion();
     }
 }

--- a/src/main/cs/Infinispan/HotRod/Impl/MetadataValueImpl.cs
+++ b/src/main/cs/Infinispan/HotRod/Impl/MetadataValueImpl.cs
@@ -8,7 +8,7 @@ namespace Infinispan.HotRod.Impl
         private long created, lastUsed;
         private int lifespan, maxIdle;
 
-        public MetadataValueImpl(V value, long version, long created, long lastUsed, int lifespan, int maxIdle) : base(value, version)
+        public MetadataValueImpl(V value, ulong version, long created, long lastUsed, int lifespan, int maxIdle) : base(value, version)
         {
             this.created = created;
             this.lastUsed = lastUsed;

--- a/src/main/cs/Infinispan/HotRod/Impl/RemoteCacheSWIGImpl.cs
+++ b/src/main/cs/Infinispan/HotRod/Impl/RemoteCacheSWIGImpl.cs
@@ -163,7 +163,7 @@ namespace Infinispan.HotRod.Impl
                 return null;
             }
             return new VersionedValueImpl<V>((V)unwrap(pair.first),
-                                             pair.second.version);
+                                             (ulong)pair.second.version);
         }
 
         public IMetadataValue<V> GetWithMetadata(K key)
@@ -174,7 +174,7 @@ namespace Infinispan.HotRod.Impl
                 return null;
             }
             return new MetadataValueImpl<V>((V)unwrap(pair.first),
-                                            pair.second.version,
+                                            (ulong)pair.second.version,
                                             pair.second.created,
                                             pair.second.lastUsed,
                                             pair.second.lifespan,

--- a/src/main/cs/Infinispan/HotRod/Impl/VersionedValueImpl.cs
+++ b/src/main/cs/Infinispan/HotRod/Impl/VersionedValueImpl.cs
@@ -6,9 +6,9 @@ namespace Infinispan.HotRod.Impl
     public class VersionedValueImpl<V> : IVersionedValue<V>
     {
         private V value;
-        private long version;
+        private ulong version;
 
-        public VersionedValueImpl(V value, long version)
+        public VersionedValueImpl(V value, ulong version)
         {
             this.value = value;
             this.version = version;
@@ -19,7 +19,7 @@ namespace Infinispan.HotRod.Impl
             return value;
         }
 
-        public long GetVersion()
+        public ulong GetVersion()
         {
             return this.version;
         }

--- a/src/test/cs/Infinispan/HotRod/Wrappers/VersionedValue.cs
+++ b/src/test/cs/Infinispan/HotRod/Wrappers/VersionedValue.cs
@@ -19,7 +19,7 @@ namespace Infinispan.HotRod.Wrappers
             return value.GetValue();
         }
 
-        public long GetVersion()
+        public ulong GetVersion()
         {
             return value.GetVersion();
         }


### PR DESCRIPTION
Changed getVersioned() type from long to ulong.

Fix for: https://issues.jboss.org/browse/HRCPP-360