### PR TITLE
HRCPP-393 Added simple SASL setup for string arguments

### DIFF
--- a/src/main/cs/Infinispan/HotRod/Config/AuthenticationCallback.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/AuthenticationCallback.cs
@@ -2,14 +2,16 @@ namespace Infinispan.HotRod.Config
 {
 #pragma warning disable 1591
     using System;
-    class InternalAuthenticationStringCallback : Infinispan.HotRod.SWIGGen.AuthenticationStringCallback
+    using SWIGGen;
+
+    class InternalAuthenticationFunctionCallback : Infinispan.HotRod.SWIGGen.AuthenticationStringCallback
     {
-        private string str;
-        public InternalAuthenticationStringCallback(string str)
-        { this.str = str; }
+        private Func<string> f_str;
+        public InternalAuthenticationFunctionCallback(Func<string> f_str)
+        { this.f_str = f_str; }
         public override string getString()
         {
-            return str;
+            return f_str();
         }
     }
 
@@ -21,14 +23,22 @@ namespace Infinispan.HotRod.Config
         SASL_CB_PASS        = 0x4004,   /* client passphrase-based secret */
         SASL_CB_GETREALM    = 0x4008    /* realm to attempt authentication in */
     }
-    public class AuthenticationStringCallback
+
+    public class AuthenticationCallback
     {
-        public AuthenticationStringCallback(string s)
+        public AuthenticationCallback(Func<string> f_s)
         {
-            iasc = new InternalAuthenticationStringCallback(s);
+            iafc = new InternalAuthenticationFunctionCallback(f_s);
         }
-        internal InternalAuthenticationStringCallback iasc;
+
+        public AuthenticationCallback(string s)
+        {
+            iafc = new InternalAuthenticationFunctionCallback(()=>s);
+        }
+
+        internal InternalAuthenticationFunctionCallback iafc;
     }
+
 
 #pragma warning restore 1591
 

--- a/src/main/cs/Infinispan/HotRod/Config/AuthenticationConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/AuthenticationConfigurationBuilder.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Infinispan.HotRod.Config
 {
 #pragma warning disable 1591
@@ -61,6 +63,17 @@ namespace Infinispan.HotRod.Config
             return this;
         }
 
+        public AuthenticationConfigurationBuilder SetupStringCallback(string user, string password, string realm)
+        {
+            AuthenticationStringCallback cbUser = new AuthenticationStringCallback(user);
+            AuthenticationStringCallback cbPass = new AuthenticationStringCallback(password);
+            AuthenticationStringCallback cbRealm = new AuthenticationStringCallback(realm);
+            IDictionary<int, AuthenticationStringCallback> cbMap = new Dictionary<int, AuthenticationStringCallback>();
+            cbMap.Add((int)SaslCallbackId.SASL_CB_USER, cbUser);
+            cbMap.Add((int)SaslCallbackId.SASL_CB_PASS, cbPass);
+            cbMap.Add((int)SaslCallbackId.SASL_CB_GETREALM, cbRealm);
+            return SetupCallback(cbMap);
+        }
 
     }
 #pragma warning restore 1591

--- a/src/test/cs/Infinispan/HotRod/AuthenticationTest.cs
+++ b/src/test/cs/Infinispan/HotRod/AuthenticationTest.cs
@@ -17,7 +17,7 @@ namespace Infinispan.HotRod.Tests
                                 .Enable()
                                 .ServerFQDN("node0")
                                 .SaslMechanism("PLAIN")
-                                .SetupStringCallback("supervisor", "lessStrongPassword", "ApplicationRealm");
+                                .SetupCallback("supervisor", "lessStrongPassword", "ApplicationRealm");
             conf.Marshaller(new JBasicMarshaller());
             Configuration c = conf.Build();
             RemoteCacheManager remoteManager = new RemoteCacheManager(c, true);
@@ -34,7 +34,7 @@ namespace Infinispan.HotRod.Tests
                                 .Enable()
                                 .ServerFQDN("node0")
                                 .SaslMechanism("DIGEST-MD5")
-                                .SetupStringCallback("supervisor", "lessStrongPassword", "ApplicationRealm");
+                                .SetupCallback("supervisor", "lessStrongPassword", "ApplicationRealm");
             conf.Marshaller(new JBasicMarshaller());
             Configuration c = conf.Build();
             RemoteCacheManager remoteManager = new RemoteCacheManager(c, true);
@@ -87,18 +87,11 @@ namespace Infinispan.HotRod.Tests
             ConfigurationBuilder conf = new ConfigurationBuilder();
             conf.AddServer().Host("127.0.0.1").Port(11222).ConnectionTimeout(90000).SocketTimeout(900);
             //registerServerCAFile(conf, "infinispan-ca.pem");
-            AuthenticationStringCallback cbUser = new AuthenticationStringCallback("supervisor");
-            AuthenticationStringCallback cbPass = new AuthenticationStringCallback("lessStrongPassword");
-            AuthenticationStringCallback cbRealm = new AuthenticationStringCallback("ApplicationRealm");
-            IDictionary<int, AuthenticationStringCallback> cbMap = new Dictionary<int, AuthenticationStringCallback>();
-            cbMap.Add((int)SaslCallbackId.SASL_CB_USER, cbUser);
-            cbMap.Add((int)SaslCallbackId.SASL_CB_PASS, cbPass);
-            cbMap.Add((int)SaslCallbackId.SASL_CB_GETREALM, cbRealm);
             conf.Security().Authentication()
                                 .Enable()
                                 .ServerFQDN(serverName)
                                 .SaslMechanism(mech)
-                                .SetupCallback(cbMap);
+                                .SetupCallback(() => "supervisor", () => "lessStrongPassword", () => "ApplicationRealm");
             conf.Marshaller(new JBasicMarshaller());
             Configuration c = conf.Build();
             RemoteCacheManager remoteManager = new RemoteCacheManager(c, true);

--- a/src/test/cs/Infinispan/HotRod/AuthenticationTest.cs
+++ b/src/test/cs/Infinispan/HotRod/AuthenticationTest.cs
@@ -7,6 +7,41 @@ namespace Infinispan.HotRod.Tests
 {
     class AuthenticationTest
     {
+
+        [Test]
+        public void PlainAutheticationTestWithEasySaslSetup()
+        {
+            ConfigurationBuilder conf = new ConfigurationBuilder();
+            conf.AddServer().Host("127.0.0.1").Port(11222).ConnectionTimeout(90000).SocketTimeout(900);
+            conf.Security().Authentication()
+                                .Enable()
+                                .ServerFQDN("node0")
+                                .SaslMechanism("PLAIN")
+                                .SetupStringCallback("supervisor", "lessStrongPassword", "ApplicationRealm");
+            conf.Marshaller(new JBasicMarshaller());
+            Configuration c = conf.Build();
+            RemoteCacheManager remoteManager = new RemoteCacheManager(c, true);
+            IRemoteCache<string, string> testCache = remoteManager.GetCache<string, string>("authCache");
+            TestPut(testCache);
+        }
+
+        [Test]
+        public void MD5AutheticationTestWithEasySaslSetup()
+        {
+            ConfigurationBuilder conf = new ConfigurationBuilder();
+            conf.AddServer().Host("127.0.0.1").Port(11222).ConnectionTimeout(90000).SocketTimeout(900);
+            conf.Security().Authentication()
+                                .Enable()
+                                .ServerFQDN("node0")
+                                .SaslMechanism("DIGEST-MD5")
+                                .SetupStringCallback("supervisor", "lessStrongPassword", "ApplicationRealm");
+            conf.Marshaller(new JBasicMarshaller());
+            Configuration c = conf.Build();
+            RemoteCacheManager remoteManager = new RemoteCacheManager(c, true);
+            IRemoteCache<string, string> testCache = remoteManager.GetCache<string, string>("authCache");
+            TestPut(testCache);
+        }
+
         [Test]
         public void PlainAutheticationTest()
         {
@@ -61,8 +96,8 @@ namespace Infinispan.HotRod.Tests
             cbMap.Add((int)SaslCallbackId.SASL_CB_GETREALM, cbRealm);
             conf.Security().Authentication()
                                 .Enable()
-                                .SaslMechanism(mech)
                                 .ServerFQDN(serverName)
+                                .SaslMechanism(mech)
                                 .SetupCallback(cbMap);
             conf.Marshaller(new JBasicMarshaller());
             Configuration c = conf.Build();

--- a/src/test/cs/Infinispan/HotRod/BaseAuthorizationTest.cs
+++ b/src/test/cs/Infinispan/HotRod/BaseAuthorizationTest.cs
@@ -52,18 +52,11 @@ namespace Infinispan.HotRod.Tests
                     .Port(HOTROD_PORT)
                     .ConnectionTimeout(90000)
                     .SocketTimeout(900);
-            AuthenticationStringCallback cbUser = new AuthenticationStringCallback(user);
-            AuthenticationStringCallback cbPass = new AuthenticationStringCallback(password);
-            AuthenticationStringCallback cbRealm = new AuthenticationStringCallback(REALM);
-            IDictionary<int, AuthenticationStringCallback> cbMap = new Dictionary<int, AuthenticationStringCallback>();
-            cbMap.Add((int)SaslCallbackId.SASL_CB_USER, cbUser);
-            cbMap.Add((int)SaslCallbackId.SASL_CB_PASS, cbPass);
-            cbMap.Add((int)SaslCallbackId.SASL_CB_GETREALM, cbRealm);
             conf.Security().Authentication()
                                 .Enable()
                                 .SaslMechanism(GetMech())
                                 .ServerFQDN(GetServerName())
-                                .SetupCallback(cbMap);
+                                .SetupCallback(user, password, REALM);
             marshaller = new JBasicMarshaller();
             conf.Marshaller(marshaller);
             Configuration c = conf.Build();


### PR DESCRIPTION
Added SetupStringCallback() that simplify SASL setup if user just needs to pass authentication data as string.

Sample of configuration:
```
            ConfigurationBuilder conf = new ConfigurationBuilder();
            conf.AddServer().Host("127.0.0.1").Port(11222).ConnectionTimeout(90000).SocketTimeout(900);
            conf.Security().Authentication()
                                .Enable()
                                .ServerFQDN("node0")
                                .SaslMechanism("PLAIN")
                                .SetupStringCallback("supervisor", "lessStrongPassword", "ApplicationRealm");
```

https://issues.jboss.org/browse/HRCPP-393