### PR TITLE
HRCPP-422 Exposed failover balancing strategy configuration

### DIFF
--- a/src/main/cs/Infinispan/HotRod/Config/ConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/Config/ConfigurationBuilder.cs
@@ -5,6 +5,7 @@ using Infinispan.HotRod.SWIG;
 namespace Infinispan.HotRod.Config
 {
 #pragma warning disable 1591
+    public delegate Transport.FailOverRequestBalancingStrategy FailOverRequestBalancingStrategyProducerDelegate();
     public class ConfigurationBuilder
     {
         private Infinispan.HotRod.SWIG.ConfigurationBuilder builder;
@@ -121,6 +122,12 @@ namespace Infinispan.HotRod.Config
         public ClusterConfigurationBuilder AddCluster(string clusterName)
         {
             return new ClusterConfigurationBuilder(this, builder.AddCluster(clusterName));
+        }
+
+        public ConfigurationBuilder BalancingStrategyProducer(Infinispan.HotRod.Config.FailOverRequestBalancingStrategyProducerDelegate d)
+        {
+            builder.BalancingStrategyProducer(d);
+            return this;
         }
 
         public ConfigurationBuilder Marshaller(IMarshaller marshaller)

--- a/src/main/cs/Infinispan/HotRod/SWIG/ConfigurationBuilder.cs
+++ b/src/main/cs/Infinispan/HotRod/SWIG/ConfigurationBuilder.cs
@@ -1,5 +1,10 @@
 using System;
+using Infinispan.HotRod.SWIGGen;
 
+namespace Infinispan.HotRod.SWIGGen
+{
+    internal delegate IntPtr FailOverRequestBalancingStrategyProducerDelegate();
+}
 namespace Infinispan.HotRod.SWIG
 {
     internal interface ConfigurationBuilder
@@ -22,5 +27,6 @@ namespace Infinispan.HotRod.SWIG
         ConfigurationBuilder TcpNoDelay(bool tcpNoDelay);
         ConfigurationBuilder ValueSizeEstimate(int valueSizeEstimate);
         ConfigurationBuilder MaxRetries(int maxRetries);
+        ConfigurationBuilder BalancingStrategyProducer(Infinispan.HotRod.Config.FailOverRequestBalancingStrategyProducerDelegate bsp);
     }
 }

--- a/src/main/cs/Infinispan/HotRod/Transport/FailOverRequestBalancingStrategy.cs
+++ b/src/main/cs/Infinispan/HotRod/Transport/FailOverRequestBalancingStrategy.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Infinispan.HotRod.SWIGGen;
+
+namespace Infinispan.HotRod
+{
+    class InternalFailOverRequestBalancingStrategy : Infinispan.HotRod.SWIGGen.FailOverRequestBalancingStrategy
+    {
+        public InternalFailOverRequestBalancingStrategy(Transport.FailOverRequestBalancingStrategy strategy) : base()
+        {
+            this.strategy = strategy;
+            this.swigCMemOwn = false;
+        }
+        public override void setServers(InetSocketAddressVector servers)
+        {
+            IList<Transport.InetSocketAddress> l = new List<Transport.InetSocketAddress>();
+            foreach (var s in servers)
+            {
+                l.Add(fromSWIGGen(s));
+            }
+            strategy.setServers(l);
+        }
+
+        public override SWIGGen.InetSocketAddress nextServer(InetSocketAddressSet failedServer)
+        {
+            IList<Transport.InetSocketAddress> l = new List<Transport.InetSocketAddress>();
+            IntPtr iter = failedServer.create_iterator_begin();
+            while (failedServer.has_next(iter))
+            {
+                l.Add(fromSWIGGen(failedServer.get_next_key(iter)));
+            }
+            failedServer.destroy_iterator(iter);
+            return toSWIGGen(strategy.nextServer(l));
+        }
+
+        Transport.InetSocketAddress fromSWIGGen(Infinispan.HotRod.SWIGGen.InetSocketAddress server)
+        {
+            Transport.InetSocketAddress ret = new Transport.InetSocketAddress();
+            ret.Hostname=server.getHostname();
+            ret.Port = server.getPort();
+            return ret;
+        }
+        Infinispan.HotRod.SWIGGen.InetSocketAddress toSWIGGen(Transport.InetSocketAddress server)
+        {
+            return new Infinispan.HotRod.SWIGGen.InetSocketAddress(server.Hostname, server.Port);
+        }
+        private Transport.FailOverRequestBalancingStrategy strategy;
+    }
+    namespace Transport
+    {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public class InetSocketAddress
+        {
+            private string hostname;
+            private int port;
+
+            public string Hostname
+            {
+                get
+                {
+                    return hostname;
+                }
+
+                set
+                {
+                    hostname = value;
+                }
+            }
+
+            public int Port
+            {
+                get
+                {
+                    return port;
+                }
+
+                set
+                {
+                    port = value;
+                }
+            }
+        }
+        public interface FailOverRequestBalancingStrategy
+        {
+            InetSocketAddress nextServer(IList<InetSocketAddress> failedServer);
+            void setServers(IList<InetSocketAddress> servers);
+        }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+    }
+}

--- a/swig/hotrod_arch.i
+++ b/swig/hotrod_arch.i
@@ -64,7 +64,14 @@
     public Infinispan.HotRod.SWIG.ClusterConfigurationBuilder AddCluster(string _clusterName) {
         return addCluster(_clusterName);
     }
-    
+
+    public Infinispan.HotRod.SWIG.ConfigurationBuilder BalancingStrategyProducer(Infinispan.HotRod.Config.FailOverRequestBalancingStrategyProducerDelegate d)
+    {
+            SWIGGen.FailOverRequestBalancingStrategyProducerDelegate id = delegate () { return (new InternalFailOverRequestBalancingStrategy(d())).myHandle(); };
+            balancingStrategyProducer(id);
+            return this;
+    }
+
     %}
 
 %typemap(csinterfaces_derived) infinispan::hotrod::ServerConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.ServerConfigurationBuilder"
@@ -82,6 +89,14 @@
         return port(_port);
     }
     %}
+
+%typemap(cscode) infinispan::hotrod::FailOverRequestBalancingStrategy %{
+        public IntPtr myHandle()
+        {
+
+            return swigCPtr.Handle;
+        }
+%}
 
 %typemap(csinterfaces_derived) infinispan::hotrod::ConnectionPoolConfigurationBuilder "IDisposable, Infinispan.HotRod.SWIG.ConnectionPoolConfigurationBuilder"
 %typemap(cscode) infinispan::hotrod::ConnectionPoolConfigurationBuilder %{
@@ -275,6 +290,13 @@ public Infinispan.HotRod.SWIG.ClusterConfigurationBuilder AddClusterNode(string 
 %}
 %typemap(csinterfaces) infinispan::hotrod::Configuration "IDisposable, Infinispan.HotRod.SWIG.Configuration"
 %typemap(cscode) infinispan::hotrod::Configuration %{
+
+FailOverRequestBalancingStrategyProducerDelegate failOverStrategyProducerDelegate;
+internal void balancingStrategyProducer(FailOverRequestBalancingStrategyProducerDelegate failOverStrategyProducerDelegate)
+{
+  this.failOverStrategyProducerDelegate = failOverStrategyProducerDelegate;
+}
+
 public System.Collections.Generic.IList<Infinispan.HotRod.SWIG.ServerConfiguration> Servers() {
         System.Collections.Generic.List<Infinispan.HotRod.SWIG.ServerConfiguration> result
             = new System.Collections.Generic.List<Infinispan.HotRod.SWIG.ServerConfiguration>();

--- a/swig/hotrod_arch.i
+++ b/swig/hotrod_arch.i
@@ -274,7 +274,7 @@
     }
 
     public Infinispan.HotRod.SWIG.NearCacheConfigurationBuilder MaxEntries(int maxEntries) {
-        return this.maxEntries(maxEntries);
+        return this.maxEntries((uint)maxEntries);
     }
 
     public int GetMaxEntries() {

--- a/swig/hotrodcs.i
+++ b/swig/hotrodcs.i
@@ -3,6 +3,18 @@
 /* Define org::infinispan::query::remote::client needed by RemoteCacheBase. This in place of including all the protobuf stuff */
 namespace org { namespace infinispan { namespace query { namespace remote { namespace client {}}}}}
 }
+
+%define %cs_callback(TYPE, CSTYPE)
+    %typemap(ctype) TYPE, TYPE& "void *"
+    %typemap(in) TYPE  %{ $1 = ($1_type)$input; %}
+    %typemap(in) TYPE& %{ $1 = ($1_type)&$input; %}
+    %typemap(imtype, out="IntPtr") TYPE, TYPE& "CSTYPE"
+    %typemap(cstype, out="IntPtr") TYPE, TYPE& "CSTYPE"
+    %typemap(csin) TYPE, TYPE& "$csinput"
+%enddef
+
+%cs_callback(infinispan::hotrod::FailOverRequestBalancingStrategy::ProducerFn, FailOverRequestBalancingStrategyProducerDelegate)
+
 %{
 #define HR_PROTO_EXPORT
 #define _WIN64
@@ -57,6 +69,7 @@ namespace org { namespace infinispan { namespace query { namespace remote { name
 %include "std_pair.i"
 %include "std_map.i"
 %include "std_vector.i"
+%include "std_set.i"
 
 %template (VectorChar) std::vector<char>;
 %template (VectorVectorChar) std::vector<std::vector<char> >;
@@ -67,6 +80,9 @@ namespace org { namespace infinispan { namespace query { namespace remote { name
 
 %feature("director") AuthenticationStringCallback;
 %feature("director") ClientListenerCallback;
+%feature("director") FailOverRequestBalancingStrategy;
+%feature("director") FailOverRequestBalancingStrategyProducer;
+%feature("director") FailOverRequestBalancingStrategyProducerDelegate;
 
 
 %inline{
@@ -116,7 +132,6 @@ static int getpath(void *context, const char ** path) {
         return SASL_BADPARAM;
     return SASL_OK;
 }
-
 }
 
 
@@ -147,6 +162,7 @@ static int getpath(void *context, const char ** path) {
 %ignore infinispan::hotrod::event::ClientCacheFailoverEvent;
 %ignore infinispan::hotrod::event::ClientCacheEntryCustomEvent;
 %ignore infinispan::hotrod::event::DotNetClientListener::getFailoverFunction;
+%ignore getBalancingStrategy;
 
 %include "infinispan/hotrod/ClientEvent.h"
 %include "infinispan/hotrod/ClientListener.h"
@@ -295,6 +311,8 @@ namespace hotrod {
 %template(ServerConfigurationVector) std::vector<infinispan::hotrod::ServerConfiguration>;
 %template(ServerConfigurationMap) std::map<std::string,std::vector<infinispan::hotrod::ServerConfiguration> >;
 %template(SaslCallbackHandlerMap) std::map<int, AuthenticationStringCallback *>;
+%template(InetSocketAddressVector) std::vector<infinispan::hotrod::transport::InetSocketAddress>;
+%template(InetSocketAddressSet) std::set<infinispan::hotrod::transport::InetSocketAddress>;
 %extend infinispan::hotrod::RemoteCacheManager {
     %template(getByteArrayCache) getCache<infinispan::hotrod::ByteArray, infinispan::hotrod::ByteArray>;
 };

--- a/swig/std_set.i
+++ b/swig/std_set.i
@@ -1,0 +1,124 @@
+/*=========================================================================
+
+  Program: GDCM (Grassroots DICOM). A DICOM library
+
+  Copyright (c) 2006-2011 Mathieu Malaterre
+  All rights reserved.
+  See Copyright.txt or http://gdcm.sourceforge.net/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+/* -----------------------------------------------------------------------------
+ * std_set.i
+ *
+ * SWIG typemaps for std::set< V >
+ *
+ * The C# wrapper is made to look and feel like a C# System.Collections.Generic.ISet<>.
+ *
+ * Using this wrapper is fairly simple. For example, to create a set of integers use:
+ *
+ *   %include <std_set.i>
+ *   %template(SetInt) std::set<int>
+ *
+ * Notes:
+ * 1) IEnumerable<> is implemented in the proxy class which is useful for using LINQ with
+ *    C++ std::set wrappers.
+ *
+ * Warning: heavy macro usage in this file. Use swig -E to get a sane view on the real file contents!
+ * ----------------------------------------------------------------------------- */
+
+%{
+#include <set>
+#include <algorithm>
+#include <stdexcept>
+%}
+
+/* V is the C++ value type */
+%define SWIG_STD_SET_INTERNAL(V)
+
+%typemap(csinterfaces) std::set< V > "IDisposable \n#if SWIG_DOTNET_3\n    , System.Collections.Generic.ISet<$typemap(cstype, V)>\n#endif\n";
+%typemap(cscode) std::set<K, T > %{
+
+  public $typemap(cstype, V) this[$typemap(cstype, V) key] {
+    get {
+      return getitem(key);
+    }
+
+    set {
+      setitem(value);
+    }
+  }
+
+//  public bool TryGetValue($typemap(cstype, V) value) {
+//    if (this.ContainsKey(key)) {
+//      value = this[key];
+//      return true;
+//    }
+//    value = default($typemap(cstype, T));
+//    return false;
+//  }
+
+  public int Count {
+    get {
+      return (int)size();
+    }
+  }
+
+  public bool IsReadOnly {
+    get {
+      return false;
+    }
+  }
+
+%}
+
+  public:
+    set();
+    set(const set< V > &other);
+
+    typedef V value_type;
+    typedef size_t size_type;
+    size_type size() const;
+    bool empty() const;
+    %rename(Clear) clear;
+    void clear();
+    %extend {
+      // create_iterator_begin(), get_next_key() and destroy_iterator work together to provide a collection of keys to C#
+      %apply void *VOID_INT_PTR { std::set< V >::iterator *create_iterator_begin }
+      %apply void *VOID_INT_PTR { std::set< V >::iterator *swigiterator }
+
+      std::set< V >::iterator *create_iterator_begin() {
+        return new std::set< V >::iterator($self->begin());
+      }
+
+      const V& get_next_key(std::set< V >::iterator *swigiterator) {
+        std::set< V >::iterator& iter = *swigiterator;
+        const V& val = *iter;
+        ++iter;
+        return val;
+      }
+
+      bool has_next(std::set< V >::iterator *swigiterator) {
+        std::set< V >::iterator iter = *swigiterator;
+        return $self->end()!=iter;
+      }
+
+
+      void destroy_iterator(std::set< V >::iterator *swigiterator) {
+        delete swigiterator;
+      }
+    }
+
+
+%enddef
+
+
+// Default implementation
+namespace std {
+  template<class V> class set {
+    SWIG_STD_SET_INTERNAL(V)
+  };
+}

--- a/templates/hotrodcs.proj.in
+++ b/templates/hotrodcs.proj.in
@@ -28,6 +28,7 @@
     <Compile Include="${W_S}\src\main\cs\Infinispan\HotRod\Config\*.cs"/>
     <Compile Include="${W_S}\src\main\cs\Infinispan\HotRod\SWIG\*.cs"/>
     <Compile Include="${W_S}\src\main\cs\Infinispan\HotRod\Event\*.cs"/>
+    <Compile Include="${W_S}\src\main\cs\Infinispan\HotRod\Transport\*.cs"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is to let the user configures the balancing strategy for failover.

Strategy must be implemented extending the class
Infinispan.HotRod.Transport.FailOverRequestBalancingStrategy

and a producer of type Infinispan.HotRod.Transport.FailOverRequestBalancingStrategyProducerDelegate must be passed as argument to the method:
Infinispan.HotRod.Config.ConfigurationBuilder.FailOverBalancingStrategy()

an example is provided in the Infinispan.HotRod.Tests.XSiteFailoverTest class


https://issues.jboss.org/browse/HRCPP-422